### PR TITLE
Added linker flags to drop debug info in header

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ extern "C" fn mainCRTStartup() -> u32 {
 /// Magic linker flags to merge sections and prevent linking _anything_
 #[allow(unused_attributes)]
 #[cfg(target_env = "msvc")]
-#[link_args = "/ALIGN:8 /FILEALIGN:1 /MERGE:.rdata=.text /MERGE:.pdata=.text /NODEFAULTLIB"]
+#[link_args = "/ALIGN:8 /FILEALIGN:1 /MERGE:.rdata=.text /MERGE:.pdata=.text /NODEFAULTLIB /EMITPOGOPHASEINFO /DEBUG:NONE"]
 extern "C" {}
 
 #[panic_handler]


### PR DESCRIPTION
This change reduces the size to 600 bytes
https://stackoverflow.com/questions/45538668/remove-image-debug-directory-from-rdata-section